### PR TITLE
adding python interpretor

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -4,5 +4,5 @@ modes to run the file. One to collect meta data, one to add those to db. Just se
 For Linux/Debian users:
 -----------------------
 
-To run the command ./nmdc.py first add '#!/usr/bin/python' ( without apostrophe )
+To run the command ./nmdc.py first add '#!/usr/bin/python' (without apostrophe)
 at the starting of the script file

--- a/README.txt
+++ b/README.txt
@@ -1,2 +1,8 @@
 Inorder to use nmdc.py, just edit the postgres db settings in the python script itself. Start the postgres server. There are two
 modes to run the file. One to collect meta data, one to add those to db. Just see the source and you will get to know
+
+For Linux/Debian users:
+-----------------------
+
+To run the command ./nmdc.py first add '#!/usr/bin/python' ( without apostrophe )
+at the starting of the script file

--- a/README.txt
+++ b/README.txt
@@ -4,5 +4,5 @@ modes to run the file. One to collect meta data, one to add those to db. Just se
 For Linux/Debian users :
 ------------------------
 
-To run the command ./nmdc.py first add '#!/usr/bin/python' (without apostrophe)
+In order to run the command ./nmdc.py first add '#!/usr/bin/python' (without apostrophe)
 at the starting of the script file

--- a/README.txt
+++ b/README.txt
@@ -1,8 +1,8 @@
 Inorder to use nmdc.py, just edit the postgres db settings in the python script itself. Start the postgres server. There are two
 modes to run the file. One to collect meta data, one to add those to db. Just see the source and you will get to know
 
-For Linux/Debian users:
------------------------
+For Linux/Debian users :
+------------------------
 
 To run the command ./nmdc.py first add '#!/usr/bin/python' (without apostrophe)
 at the starting of the script file

--- a/nmdc.py
+++ b/nmdc.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 import re
 import os
 import bz2


### PR DESCRIPTION
While running ./nmdc.py in Kali Linux it was not running
so I added the first line to run it with python interpretor and now its working
